### PR TITLE
Align with YARP 3.1.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,11 +6,10 @@
 cmake_minimum_required(VERSION 2.8.9)
 
 find_package(YARP)
+set(YARP_REQUIRED_VERSION 3.1.0)
 find_package(ICUBcontrib)
-list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH}
-                              ${ICUBCONTRIB_MODULE_PATH})
+list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
 
-include(YarpInstallationHelpers)
 include(ICUBcontribHelpers)
 include(ICUBcontribOptions)
 icubcontrib_set_default_prefix()

--- a/src/descriptorReduction/CMakeLists.txt
+++ b/src/descriptorReduction/CMakeLists.txt
@@ -10,11 +10,9 @@ find_package(YARP)
 find_package(ICUB)
 find_package(ICUBcontrib)
 
-list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
 list(APPEND CMAKE_MODULE_PATH ${ICUB_MODULE_PATH})
 list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
 
-include(YarpInstallationHelpers)
 include(ICUBcontribHelpers)
 include(ICUBcontribOptions)
 icubcontrib_set_default_prefix()
@@ -26,7 +24,6 @@ source_group("Source Files" FILES ${source})
 source_group("Header Files" FILES ${header})
 
 include_directories(${PROJECT_SOURCE_DIR}/include
-                    ${YARP_INCLUDE_DIRS}
                     ${ICUB_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME} ${source} ${header})

--- a/src/handActions/CMakeLists.txt
+++ b/src/handActions/CMakeLists.txt
@@ -15,16 +15,13 @@ find_package(YARP REQUIRED)
 find_package(ICUBcontrib REQUIRED)
 
 # extend the current search path used by cmake to load helpers
-list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
 list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
 
-# helpers defining certain macros (e.g. "yarp_install")
-include(YarpInstallationHelpers)
+# helpers defining certain macros
 include(ICUBcontribHelpers)
 include(ICUBcontribOptions)
 
 # Thrift IDL
-include(YarpIDL)
 #yarp_add_idl(IDL_GEN_FILES ${PROJECT_NAME}.thrift)
 #set(idl ${PROJECT_NAME}.thrift)
 set(idl_files ${PROJECT_NAME}.thrift)
@@ -35,7 +32,6 @@ source_group("IDL Files" FILES ${idl_files})
 icubcontrib_set_default_prefix()
 
 include_directories(${PROJECT_SOURCE_DIR}/include
-                    ${YARP_INCLUDE_DIRS}
                     ${IDL_GENERATED_CODE_DIR}/include)
 add_executable(${PROJECT_NAME} src/main.cpp
                                src/HandActionsModule.cpp

--- a/src/handActions/include/HandActionsModule.h
+++ b/src/handActions/include/HandActionsModule.h
@@ -39,13 +39,13 @@ protected:
     yarp::dev::IGazeControl *igaze;
     yarp::dev::IEncoders *encsA;
     yarp::dev::ICartesianControl *iarm;
-    yarp::dev::IPositionControl2 *posA;
-    yarp::dev::IPositionControl2 *posAOther;
-    yarp::dev::IPositionControl2 *posT;
+    yarp::dev::IPositionControl *posA;
+    yarp::dev::IPositionControl *posAOther;
+    yarp::dev::IPositionControl *posT;
 
-    yarp::dev::IControlMode2 *ctrlMA;
-    yarp::dev::IControlMode2 *ctrlMAOther;
-    yarp::dev::IControlMode2 *ctrlMT;
+    yarp::dev::IControlMode *ctrlMA;
+    yarp::dev::IControlMode *ctrlMAOther;
+    yarp::dev::IControlMode *ctrlMT;
 
     bool closing;
     bool twoArms;

--- a/src/handAffManager/CMakeLists.txt
+++ b/src/handAffManager/CMakeLists.txt
@@ -19,16 +19,13 @@ find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED filesystem system)
 
 # extend the current search path used by cmake to load helpers
-list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
 list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
 
-# helpers defining certain macros (e.g. "yarp_install")
-include(YarpInstallationHelpers)
+# helpers defining certain macros
 include(ICUBcontribHelpers)
 include(ICUBcontribOptions)
 
 # Thrift IDL
-include(YarpIDL)
 set(idl_files ${PROJECT_NAME}.thrift)
 yarp_add_idl(IDL_GEN_FILES ${idl_files})
 source_group("IDL Files" FILES ${idl_files})
@@ -38,7 +35,6 @@ icubcontrib_set_default_prefix()
 
 include_directories(${PROJECT_SOURCE_DIR}/include
                     ${PROJECT_SOURCE_DIR}/../common/include
-                    ${YARP_INCLUDE_DIRS}
                     ${OpenCV_INCLUDE_DIRS}
                     ${IDL_GENERATED_CODE_DIR}/include
                     ${Boost_FILESYSTEM_INCLUDE_DIRS}

--- a/src/handAffManager/src/HandAffManagerModule.cpp
+++ b/src/handAffManager/src/HandAffManagerModule.cpp
@@ -396,7 +396,7 @@ bool HandAffManagerModule::getHandDesc()
     {
         const int expectedDescSize = 41;
         if (inHandDesc->size() != expectedDescSize)
-            yError("got %d hand descriptors instead of %d", inHandDesc->size(), expectedDescSize);
+            yError("got %zu hand descriptors instead of %d", inHandDesc->size(), expectedDescSize);
 
         handDesc.clear();
 
@@ -509,7 +509,7 @@ bool HandAffManagerModule::getObjDesc()
     {
         const int expectedDescSize = 41;
         if (inObjDesc->size() != expectedDescSize)
-            yError("got %d object descriptors instead of %d", inObjDesc->size(), expectedDescSize);
+            yError("got %zu object descriptors instead of %d", inObjDesc->size(), expectedDescSize);
 
         objDesc.clear();
 
@@ -803,21 +803,21 @@ bool HandAffManagerModule::saveDesc(const string &label)
         // hand
         if (handDesc.size() != numDesc)
         {
-            yError("got %d hand descriptors, was expecting %d", handDesc.size(), numDesc);
+            yError("got %zu hand descriptors, was expecting %d", handDesc.size(), numDesc);
             return false;
         }
 
         const int numArmJoints = 16;
         if (armJoints.size() != numArmJoints)
         {
-            yError("got %d arm joints, was expecting %d", armJoints.size(), numArmJoints);
+            yError("got %zu arm joints, was expecting %d", armJoints.size(), numArmJoints);
             return false;
         }
 
         const int numHeadJoints = 6;
         if (headJoints.size() != numHeadJoints)
         {
-            yError("got %d head joints, was expecting %d", headJoints.size(), numHeadJoints);
+            yError("got %zu head joints, was expecting %d", headJoints.size(), numHeadJoints);
             return false;
         }
 
@@ -839,7 +839,7 @@ bool HandAffManagerModule::saveDesc(const string &label)
         // object
         if (objDesc.size() != numDesc)
         {
-            yError("got %d object descriptors, was expecting %d", objDesc.size(), numDesc);
+            yError("got %zu object descriptors, was expecting %d", objDesc.size(), numDesc);
             return false;
         }
 
@@ -1019,7 +1019,7 @@ bool HandAffManagerModule::saveEffects(const string &posture,
     const int numEffects = 8;
     if (effects.size() != numEffects)
     {
-        yError("got %d effects, was expecting %d", effects.size(), numEffects);
+        yError("got %zu effects, was expecting %d", effects.size(), numEffects);
         return false;
     }
 

--- a/src/robotHandProcessor/CMakeLists.txt
+++ b/src/robotHandProcessor/CMakeLists.txt
@@ -15,16 +15,13 @@ find_package(ICUBcontrib REQUIRED)
 find_package(OpenCV REQUIRED)
 
 # extend the current search path used by cmake to load helpers
-list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
 list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
 
-# helpers defining certain macros (e.g. "yarp_install")
-include(YarpInstallationHelpers)
+# helpers defining certain macros
 include(ICUBcontribHelpers)
 include(ICUBcontribOptions)
 
 # Thrift IDL
-include(YarpIDL)
 set(idl_files ${PROJECT_NAME}.thrift)
 yarp_add_idl(IDL_GEN_FILES ${idl_files})
 source_group("IDL Files" FILES ${idl_files})
@@ -38,7 +35,6 @@ source_group("Source Files" FILES ${folder_source})
 source_group("Header Files" FILES ${folder_header})
 
 include_directories(${PROJECT_SOURCE_DIR}/include
-                    ${YARP_INCLUDE_DIRS}
                     ${OpenCV_INCLUDE_DIRS}
                     ${IDL_GENERATED_CODE_DIR}/include)
 add_executable(${PROJECT_NAME} ${folder_source}

--- a/src/shapeDescriptor/CMakeLists.txt
+++ b/src/shapeDescriptor/CMakeLists.txt
@@ -10,13 +10,11 @@ find_package(YARP)
 find_package(ICUB)
 find_package(ICUBcontrib)
 
-list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
 list(APPEND CMAKE_MODULE_PATH ${ICUB_MODULE_PATH})
 list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
 
 find_package(OpenCV)
 
-include(YarpInstallationHelpers)
 include(ICUBcontribHelpers)
 include(ICUBcontribOptions)
 icubcontrib_set_default_prefix()
@@ -29,7 +27,6 @@ source_group("Header Files" FILES ${header})
 
 include_directories(${PROJECT_SOURCE_DIR}/include
                     ${PROJECT_SOURCE_DIR}/../common/include
-                    ${YARP_INCLUDE_DIRS}
                     ${ICUB_INCLUDE_DIRS})
 
 # import math symbols from standard cmath

--- a/src/shapeDescriptor/src/DescriptorThread.cpp
+++ b/src/shapeDescriptor/src/DescriptorThread.cpp
@@ -425,7 +425,7 @@ void ShapeDescriptorThread::run2d()
             addDescriptors(parts[o].second, botBot);
         }
         t1 = yarp::os::Time::now();
-        yDebug("computed descriptors of %d objects (whole and parts) in %f msec",
+        yDebug("computed descriptors of %zu objects (whole and parts) in %f msec",
                bDesc.size(), 1000.0*(t1-t0));
         outPartDescPort.setEnvelope(tsBin);
         outPartDescPort.write();


### PR DESCRIPTION
* enforce YARP >= 3.1.0
* remove deprecated CMake macros
* rename `yarp::dev` control interfaces
* fix a few other compilation warnings

See #21